### PR TITLE
Пропуск тега Doctype

### DIFF
--- a/src/parsexml.erl
+++ b/src/parsexml.erl
@@ -11,7 +11,12 @@ parse(Bin) when is_binary(Bin) ->
 
 skip_declaration(<<"<?xml", Bin/binary>>) ->
   [_,Rest] = binary:split(Bin, <<"?>">>),
-  trim(Rest);
+  trim(Rest),
+  skip_declaration(Rest);
+
+skip_declaration(<<"<!", Bin/binary>>) ->
+	[_,Rest] = binary:split(Bin, <<">">>),
+	trim(Rest);
 
 skip_declaration(<<"<",_/binary>> = Bin) -> Bin;
 skip_declaration(<<_,Bin/binary>>) -> skip_declaration(Bin).

--- a/test/parsexml_tests.erl
+++ b/test/parsexml_tests.erl
@@ -27,6 +27,8 @@ parse_test_() ->
     parsexml:parse(<<"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<html k=\"v\"/>\n">>))
   ,?_assertEqual({<<"html">>, [{<<"k">>,<<"v">>}], []}, 
     parsexml:parse(<<"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<html k=\"v\" />\n">>))
+  ,?_assertEqual({<<"html">>, [{<<"k">>,<<"v">>}], []},
+    parsexml:parse(<<"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<!DOCTYPE some_dtd SYSTEM \"example.dtd\">\n<html k=\"v\" />\n">>))
   ].
 
 parse2_test() ->

--- a/test/test1.xml
+++ b/test/test1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE some_dtd SYSTEM "example.dtd">
 <p:program channel="otv" xmlns:p="http://otv/ns">
 <p:day date="2011-10-19">
 <p:item id="2877" href="http://otv/15/" title="New"/>


### PR DESCRIPTION
Во многих XML присутствует тег <!DOCTYPE ... >, который также неплохо бы пропускать. Собственно, этот пропуск и добавил.
